### PR TITLE
Change shore hardness name and category to be consistent with openprinttag-architecture

### DIFF
--- a/data/main_fields.yaml
+++ b/data/main_fields.yaml
@@ -301,19 +301,17 @@
 # Removed 19
 
 - key: 31
-  name: shore_hardness_a
+  name: hardness_shore_a
   type: int
   example: 95
-  category: fff
   description:
     - Hardness of the material on the Shore A hardness scale (suitable for softer materials).
     - "**Note:** There is no 1:1 mapping between A and D scales, different materials can have different values on one scale even though they are the same on the other."
 
 - key: 32
-  name: shore_hardness_d
+  name: hardness_shore_d
   type: int
   example: 30
-  category: fff
   description:
     - Hardness of the material on the Shore D hardness scale (suitable for harder materials).
     - "**Note:** There is no 1:1 mapping between A and D scales, different materials can have different values on one scale even though they are the same on the other."

--- a/utils/schema/fields.schema.json
+++ b/utils/schema/fields.schema.json
@@ -129,10 +129,10 @@
                 "filament_diameter": {
                     "$ref": "field_types.schema.json#/definitions/number"
                 },
-                "shore_hardness_a": {
+                "hardness_shore_a": {
                     "$ref": "field_types.schema.json#/definitions/int"
                 },
-                "shore_hardness_d": {
+                "hardness_shore_d": {
                     "$ref": "field_types.schema.json#/definitions/int"
                 },
                 "min_nozzle_diameter": {


### PR DESCRIPTION
The specification declares FFF-specific fields `shore_hardness_a` and `shore_hardness_d`. This is inconsistent with `openprinttag-architecture`, which instead specifies `hardness_shore_a` and `hardness_shore_d` for both material types. I suggest fixing this inconsistency here by removing the `category` from both fields and renaming them, while keeping the same key.